### PR TITLE
chore: pin engine 0.2.45; release 0.1.74

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FERS"
-version = "0.1.73"
+version = "0.1.74"
 description = "Finite Element Method library written in Rust with Python interface"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ dependencies = [
     "ujson>=5.10.0",
     "sectionproperties>=3.7.0",
     "pyvista>=0.44.0",
-    "fers_calculations==0.2.44",
+    "fers_calculations==0.2.45",
     "pydantic>=2.10.0",
     "scipy>=1.14.0",
     "ezdxf>=1.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.9.2
 ujson==5.10.0
 sectionproperties==3.7.0
 pyvista==0.47.1
-fers_calculations==0.2.44
+fers_calculations==0.2.45
 pydantic==2.10.4
 scipy==1.14.1
 pre_commit==4.0.0


### PR DESCRIPTION
fers 0.1.73 published with fers_calculations==0.2.44, which understates end-peaked unity-check demands by up to ~25% and never runs EC3 6.3.1/6.3.3 on compressed members. 0.2.45 (verified complete on PyPI) carries the fixes.