### PR TITLE
feat: ResultBlock + AnalysisOptions.result_filter; pin engine 0.2.48 …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.1.76
+
+### Added
+- **`AnalysisOptions.result_filter`** + **`ResultBlock`** enum (engine ≥
+  0.2.48): whitelist of result blocks the engine should emit. `None`
+  (default) keeps today's full output; a unity-check/envelope consumer
+  typically wants `[ResultBlock.LOCAL_ENVELOPES,
+  ResultBlock.NODE_DISPLACEMENTS, ResultBlock.REACTIONS]`, which shrinks
+  large responses ~85–90% (the fix for the `result-filtering` OOM feedback).
+  Older engines ignore the field. Unity checks always evaluate on the full
+  results regardless of the filter; `member_displacements` stays governed by
+  `include_member_deflected_shape`.
+- The engine wheel also gained `fers_calculations.calculate_to_file(
+  json_data, output_path, api_key=None)` — solve and stream the result JSON
+  to a file so the response string never lives in the Python heap; composes
+  with `result_filter`.
+
+### Changed
+- **Pin `fers_calculations==0.2.48`.** Schema loosening in 0.2.48: the ten
+  scalar `MemberResult` blocks are now `Optional` in the generated result
+  models (they are absent only when explicitly filtered out; unfiltered
+  output is unchanged).
+
 ## 0.1.75
 
 ### Changed

--- a/fers_core/__init__.py
+++ b/fers_core/__init__.py
@@ -48,6 +48,7 @@ from .settings.anlysis_options import (
     NonlinearMethod,
     PdeltaFormulation,
     PdeltaMode,
+    ResultBlock,
     RigidStrategy,
 )
 from .settings.enums import MassFormulation
@@ -128,6 +129,7 @@ __all__ = [
     "PdeltaFormulation",
     "PdeltaMode",
     "ReactionNodeResult",
+    "ResultBlock",
     "ResultRenderer",
     "ResultsBundle",
     "RigidStrategy",

--- a/fers_core/settings/anlysis_options.py
+++ b/fers_core/settings/anlysis_options.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 from ..settings.enums import (
     AnalysisOrder,
     Dimensionality,
     NonlinearMethod,
     PdeltaFormulation,
     PdeltaMode,
+    ResultBlock,
     RigidStrategy,
 )
 
@@ -24,6 +25,21 @@ class AnalysisOptions:
     fers_core 0.1.70 — wires built with ≤ 0.1.69 builder objects always ran
     the engine default ``FULL``, even when the author intended
     ``IN_PLANE_ONLY``.
+
+    Result filtering (engine >= 0.2.48): ``result_filter`` is a whitelist of
+    result blocks to emit — ``None`` (default) returns the full output. A
+    unity-check/envelope consumer typically only needs::
+
+        AnalysisOptions(result_filter=[
+            ResultBlock.LOCAL_ENVELOPES,
+            ResultBlock.NODE_DISPLACEMENTS,
+            ResultBlock.REACTIONS,
+        ])
+
+    which shrinks large responses ~85–90%. An empty list is a maximal strip;
+    the sampled deflected shape stays governed solely by
+    ``include_member_deflected_shape``, and unity checks always evaluate on
+    the full results regardless of the filter. Older engines ignore the field.
     """
 
     _analysis_options_counter = 1
@@ -51,6 +67,7 @@ class AnalysisOptions:
         gravity_factor: Optional[float] = None,
         self_weight_load_case_id: Optional[int] = None,
         include_member_deflected_shape: Optional[bool] = None,
+        result_filter: Optional[List[Union[ResultBlock, str]]] = None,
     ):
         self.analysis_options_id = id or AnalysisOptions._analysis_options_counter
         if id is None:
@@ -80,6 +97,9 @@ class AnalysisOptions:
         # When set, the solver returns each member result's sampled deflected shape
         # (`member_displacements`) for load-exact deformation plots. Off by default.
         self.include_member_deflected_shape = include_member_deflected_shape
+        # Whitelist of result blocks to emit (None = full output). Items may be
+        # ResultBlock members or their raw wire strings.
+        self.result_filter = list(result_filter) if result_filter is not None else None
 
     def to_dict(self):
         data = {
@@ -119,6 +139,14 @@ class AnalysisOptions:
             data["self_weight_load_case_id"] = self.self_weight_load_case_id
         if self.include_member_deflected_shape is not None:
             data["include_member_deflected_shape"] = self.include_member_deflected_shape
+        # Only emitted when set: the engine treats an absent filter as "emit
+        # everything" (and its `Option<Vec<..>>` accepts null, but omitting keeps
+        # wires clean and backward compatible with older engines).
+        if self.result_filter is not None:
+            data["result_filter"] = [
+                block.value if isinstance(block, ResultBlock) else str(block)
+                for block in self.result_filter
+            ]
         return data
 
     @classmethod
@@ -174,6 +202,15 @@ class AnalysisOptions:
         pdelta_formulation = parse_enum(PdeltaFormulation, data.get("pdelta_formulation"), None)
         pdelta_mode = parse_enum(PdeltaMode, data.get("pdelta_mode"), None)
 
+        # Result filter: absent → None (full output). Unknown tokens are kept
+        # as raw strings so newer-engine wires round-trip through older SDKs.
+        raw_filter = data.get("result_filter")
+        result_filter = (
+            [parse_enum(ResultBlock, item, item) for item in raw_filter]
+            if raw_filter is not None
+            else None
+        )
+
         return cls(
             id=data.get("id"),
             solve_loadcases=data.get("solve_loadcases", True),
@@ -196,4 +233,5 @@ class AnalysisOptions:
             gravity_factor=data.get("gravity_factor"),
             self_weight_load_case_id=data.get("self_weight_load_case_id"),
             include_member_deflected_shape=data.get("include_member_deflected_shape"),
+            result_filter=result_filter,
         )

--- a/fers_core/settings/enums.py
+++ b/fers_core/settings/enums.py
@@ -68,3 +68,26 @@ class PdeltaMode(Enum):
 
     FULL = "FULL"
     IN_PLANE_ONLY = "IN_PLANE_ONLY"
+
+
+class ResultBlock(Enum):
+    """Selectable result-block groups for ``AnalysisOptions.result_filter``.
+
+    Values match the Rust ``ResultBlock`` enum (engine >= 0.2.48; older
+    engines silently ignore ``result_filter`` and return the full output).
+    Each token names the member/result JSON block(s) it keeps: when a filter
+    list is present, only the listed blocks are emitted — scalar member
+    blocks are omitted, list/map blocks (``section_forces``,
+    ``internal_force_series``, ``displacement_nodes``, ``reaction_nodes``)
+    are emitted empty.
+    """
+
+    LOCAL_ENVELOPES = "local_envelopes"
+    GLOBAL_ENVELOPES = "global_envelopes"
+    LOCAL_END_FORCES = "local_end_forces"
+    GLOBAL_END_FORCES = "global_end_forces"
+    SECTION_FORCES = "section_forces"
+    INTERNAL_FORCE_SERIES = "internal_force_series"
+    LOCAL_DISPLACEMENTS = "local_displacements"
+    NODE_DISPLACEMENTS = "node_displacements"
+    REACTIONS = "reactions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FERS"
-version = "0.1.75"
+version = "0.1.76"
 description = "Finite Element Method library written in Rust with Python interface"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ dependencies = [
     "ujson>=5.10.0",
     "sectionproperties>=3.7.0",
     "pyvista>=0.44.0",
-    "fers_calculations==0.2.47",
+    "fers_calculations==0.2.48",
     "pydantic>=2.10.0",
     "scipy>=1.14.0",
     "ezdxf>=1.3.0",


### PR DESCRIPTION
…(release 0.1.76)

Exposes engine 0.2.48's result filtering: result_filter is a whitelist of result blocks to emit (None = full output, unchanged). The envelope-only profile [ResultBlock.LOCAL_ENVELOPES, ResultBlock.NODE_DISPLACEMENTS, ResultBlock.REACTIONS] shrinks large responses ~80-90% — the fix for the result-filtering OOM feedback. Unknown tokens round-trip as raw strings. The engine wheel also gained calculate_to_file(json, path, api_key=None) for file-streamed results.

pydantic_models.py syncs from the engine types regen after 0.2.48 lands (the ten scalar MemberResult blocks become Optional).